### PR TITLE
Enable HTTPS support for the `EXTERNAL_URL`

### DIFF
--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -2,9 +2,9 @@
 
 EXTERNAL_URL=${EXTERNAL_URL:-$(curl icanhazip.com)}
 if [ -n "${EXTERNAL_SERVER_PORT}" ]; then
-    sed -i "s|SERVERURL|http://${EXTERNAL_URL}:${EXTERNAL_SERVER_PORT}|g" /defaults/servers.json
+    sed -i "s|SERVERURL|${EXTERNAL_URL}:${EXTERNAL_SERVER_PORT}|g" /defaults/servers.json
 else
-    sed -i "s|SERVERURL|http://${EXTERNAL_URL}|g" /defaults/servers.json
+    sed -i "s|SERVERURL|${EXTERNAL_URL}|g" /defaults/servers.json
 fi
 
 if [ -n "${AUTH_LIST}" ]; then


### PR DESCRIPTION
## Description:

This PR enables the use of other protocols for the External URL (mainly HTTPS). This will allow synclounge to work through a reverse proxy with HTTPS enabled.


## Benefits of this PR and context:
This will enable synclounge to work through a reverse proxy with HTTPS enabled. Existing installations shouldn't be affected,

## How Has This Been Tested?

I haven't had a chance to test yet. Presumably I can build the container & test it.
